### PR TITLE
chore(images): turn off Vercel runtime optimiser (unoptimized=true)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,8 @@ const nextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 
   images: {
+    /** Disable Vercel’s runtime optimiser – stops cache-read billing */
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated image handling settings to disable runtime image optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->