### PR TITLE
add reading time estimation to blog posts

### DIFF
--- a/src/app/api/blog-content/route.ts
+++ b/src/app/api/blog-content/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import fs from "fs"
+import path from "path"
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const slug = searchParams.get("slug")
+
+  if (!slug) {
+    return NextResponse.json({ error: "Slug is required" }, { status: 400 })
+  }
+
+  try {
+    const filePath = path.join(process.cwd(), "src/app/blog", slug, "page.mdx")
+    const content = fs.readFileSync(filePath, "utf8")
+
+    // Remove frontmatter and imports to get just the content
+    const cleanContent = content
+      .replace(/^---[\s\S]*?---/, "")
+      .replace(/^import[\s\S]*?from[\s\S]*?$/gm, "")
+      .trim()
+
+    return NextResponse.json({ content: cleanContent })
+  } catch (error) {
+    console.error("Error reading blog content:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch blog content" },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,18 @@
+import { getMetadata } from "@/lib/metadata"
+import CoverImage from "./cover.png"
+import React from "react"
+
+export const metadata = getMetadata({
+    path: "/blog",
+    title: "Blog | DevTools Academy",
+    description: "Learn about awesome developer tools with our blogs",
+    image: CoverImage.src,
+})
+
+export default function BlogLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return children
+}

--- a/src/components/blog/BlogHeader.tsx
+++ b/src/components/blog/BlogHeader.tsx
@@ -6,7 +6,8 @@ import BlogChatInterface from "@/components/blog/BlogChatInterface"
 import ViewCounter from "@/components/blog/ViewCounter"
 import SocialShare from "@/components/blog/SocialShare"
 import Breadcrumb from "@/components/blog/Breadcrumb"
-import { CircleUserRound } from "lucide-react"
+import { CircleUserRound, Clock } from "lucide-react"
+import { calculateReadingTime } from "@/lib/utils"
 
 interface BlogHeaderProps {
   title: string
@@ -21,11 +22,14 @@ const BlogHeader: React.FC<BlogHeaderProps> = ({
 }) => {
   const [content, setContent] = useState("")
   const [showChat, setShowChat] = useState(false)
+  const [readTime, setReadTime] = useState<number>(0)
 
   React.useEffect(() => {
     const ele = document.querySelector("article")
     if (ele !== null) {
-      setContent(ele.innerHTML)
+      const articleContent = ele.innerHTML
+      setContent(articleContent)
+      setReadTime(calculateReadingTime(articleContent))
     }
   }, [])
 
@@ -58,6 +62,11 @@ const BlogHeader: React.FC<BlogHeaderProps> = ({
           </span>
           <span>|</span>
           <span className="text-sm">{formatDate(publishedAt)}</span>
+          <span>|</span>
+          <span className="flex items-center gap-1 text-sm">
+            <Clock size={14} />
+            {readTime} min read
+          </span>
           <span>|</span>
           <SocialShare title={title} />
         </div>


### PR DESCRIPTION
- Add reading time calculation based on actual blog content
- API endpoint to fetch blog content for accurate reading time
- Update BlogHeader, FeaturedPosts, and blog list page to display reading time
- Add fallback to excerpt/description-based calculation if content fetch fails
- metadata to layout file to fix client component issues

![CleanShot 2025-05-25 at 01 53 29@2x](https://github.com/user-attachments/assets/3e71227e-9b87-4bae-9333-7d262b039dad)
